### PR TITLE
Add clojure/test.check 0.9.0 plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :plugins [[lein-kibit "0.1.2"]
             [lein-cljfmt "0.3.0"]
             [jonase/eastwood "0.2.2"]]
-  :dependencies [[org.clojure/clojure "1.7.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/test.check "0.9.0"]]
   :main ^:skip-aot sicp.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
# [test.check](https://github.com/clojure/test.check)

test.check is a Clojure property-based testing tool inspired by QuickCheck. The core idea of test.check is that instead of enumerating expected input and output for unit tests, you write properties about your function that should hold true for all inputs. This lets you write concise, powerful tests.
