### PR TITLE
Add sicp-generator plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,12 @@
             :url "https://opensource.org/licenses/MIT"}
   :plugins [[lein-kibit "0.1.2"]
             [lein-cljfmt "0.3.0"]
+            [lein-gen "0.2.1"]
             [jonase/eastwood "0.2.2"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/test.check "0.9.0"]
                  [quil "2.3.0"]]
+  :generators [[sicp-generator "0.1.2"]]
   :main ^:skip-aot sicp.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
### Add [sicp-generator](https://clojars.org/sicp-generator) leiningen plugin
#### Usage:

```
lein generate exercise 2 63
Creating file src/sicp/chapter02/2_63.clj
Creating file test/sicp/chapter02/2_63_test.clj
Creating file doc/chapter02/ex_2_63.md
```
