### PR TITLE
Add CI action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: lein deps
+    - name: Run tests
+      run: lein test


### PR DESCRIPTION
Открыл проект впервые с 2017 года и к моему удивлению он просто запустился. Все тесты прошли успешно с первого раза. Ни одной потерянной зависимости. Удивлён.

А вот используемый изначально в качестве CI сервис TravisCI более недоступен. Поэтому добавляю сборку проекта на GitHub.
